### PR TITLE
Fix wasapi check

### DIFF
--- a/addon/globalPlugins/soundSplitter/__init__.py
+++ b/addon/globalPlugins/soundSplitter/__init__.py
@@ -55,13 +55,17 @@ def isUsingWASAPI() -> bool:
 		# Some NVDA alphas used wasapi, while the newer approach is to use WASAPI. Must test both, WASAPI first.
 		usingWASAPI: bool = False
 		try:  # Modern alphas (2023.3 series)
-			usingWASAPI = config.conf.spec["audio"]["WASAPI"]
+			config.conf.spec["audio"]["WASAPI"]
 		except KeyError:
 			try:  # Alphas earlier in the 2023.2 series
-				usingWASAPI = config.conf.spec["audio"]["wasapi"]
+				config.conf.spec["audio"]["wasapi"]
 			except KeyError:
 				# We only get here, if neither of them exists.
 				pass
+			else:
+				usingWASAPI = config.conf["audio"]["wasapi"]
+		else:
+			usingWASAPI = config.conf["audio"]["WASAPI"]
 		return usingWASAPI
 	# If this is the first run, establish the state for all future runs
 	if _usingWASAPIAtStartup is None:


### PR DESCRIPTION
### Issue
WASAPI check has been modified recently to take care of the capitalization of the option. Unfortunately,it does not work anymore.

The config spec was checked, thus it always returned trhue in 2023.2beta1.

### Solution
For each option (uppercase WASAPI or lowercase wasapi):
* first check in the config spec that the option exists
* if yes, check the value of the option in the config.

### Tests

Tested with NVDA 2023.2beta1 with three possible choices for WASAPI (enabled, disabled or default/disabled). My config also still contains the old now unused lowercase "wasapi".

